### PR TITLE
Fixed error InstallScripts: LWM2M_DIR dataDir -> getDataDir()

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/install/InstallScripts.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/InstallScripts.java
@@ -267,7 +267,7 @@ public class InstallScripts {
     }
 
     public void loadSystemLwm2mResources() {
-        Path resourceLwm2mPath = Paths.get(dataDir, MODELS_LWM2M_DIR);
+        Path resourceLwm2mPath = Paths.get(getDataDir(), MODELS_LWM2M_DIR);
         try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(resourceLwm2mPath, path -> path.toString().endsWith(InstallScripts.XML_EXT))) {
             dirStream.forEach(
                     path -> {


### PR DESCRIPTION
## Pull Request description
when I install release-3.5, I found LWM2M_DIR is wrong, so I fix this bug .
`resource lwm2m object model from file`

like thingsborard, many people like use last version , although the release-3.6 is right use getDataDir find LWM2M_DIR




