### PR TITLE
Fix kafka pending events during sync

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/cloud/BaseCloudManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/cloud/BaseCloudManagerService.java
@@ -712,7 +712,7 @@ public abstract class BaseCloudManagerService extends TbApplicationEventListener
                     .toList();
 
             if (uplinkMsgPack.isEmpty()) {
-                return Futures.immediateFuture(true);
+                return Futures.immediateFuture(false);
             }
 
             processMsgPack(uplinkMsgPack, isGeneralMsg);

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSession.java
@@ -45,8 +45,6 @@ import java.util.function.BiConsumer;
 
 @Slf4j
 public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
-    private static final int MAX_PROCESS_EDGE_EVENT_ATTEMPTS = 3;
-
     private final TopicService topicService;
     private final TbCoreQueueFactory tbCoreQueueFactory;
     private final KafkaAdmin kafkaAdmin;


### PR DESCRIPTION
## Pull Request description

Problem: Pending Kafka cloud events were skipped during tenant initialization or sync, causing relation and attribute requests to be lost.
Fix: Added buffering of pending events and ensured they are processed once sync is complete. 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard-edge/issues/147).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



