### PR TITLE
feat Add grace period before force-reconnect while awaiting edge conf…

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/cloud/rpc/BaseGrpcClientManager.java
+++ b/application/src/main/java/org/thingsboard/server/service/cloud/rpc/BaseGrpcClientManager.java
@@ -76,6 +76,7 @@ public class BaseGrpcClientManager extends TbApplicationEventListener<PartitionC
     private ScheduledExecutorService reconnectExecutor;
     private ScheduledFuture<?> connectFuture;
     private ScheduledFuture<?> reconnectFuture;
+    private volatile long lastReconnectAttemptTs;
 
     @Override
     protected void onTbApplicationEvent(PartitionChangeEvent event) {
@@ -173,7 +174,19 @@ public class BaseGrpcClientManager extends TbApplicationEventListener<PartitionC
         connectionStatusManager.updateConnectivityStatus(false);
 
         if (reconnectFuture == null) {
+            lastReconnectAttemptTs = 0;
             reconnectFuture = reconnectExecutor.scheduleAtFixedRate(() -> {
+                // This task is cancelled in onEdgeUpdate() once the server delivers the
+                // EdgeConfiguration. A busy server (e.g. draining a large backlog after an
+                // outage) may need more than one reconnect period for that, and tearing the
+                // fresh connection down again would restart the handshake from scratch in an
+                // endless loop. So after a successful connect attempt, give the server a few
+                // periods of grace before force-reconnecting.
+                long gracePeriodMs = edgeInfo.getReconnectTimeoutMs() * 3;
+                if (lastReconnectAttemptTs > 0 && System.currentTimeMillis() - lastReconnectAttemptTs < gracePeriodMs) {
+                    log.debug("Connect attempt is in progress, awaiting edge configuration from the server");
+                    return;
+                }
                 log.info("Trying to reconnect due to the error: {}!", e.getMessage());
                 try {
                     edgeRpcClient.disconnect(true);
@@ -186,6 +199,7 @@ public class BaseGrpcClientManager extends TbApplicationEventListener<PartitionC
                             this::onEdgeUpdate,
                             this::onDownlink,
                             this::scheduleReconnect);
+                    lastReconnectAttemptTs = System.currentTimeMillis();
                 } catch (Exception ex) {
                     log.error("Exception during connect: {}", ex.getMessage());
                 }


### PR DESCRIPTION
## Pull Request description

handle reconnects gracefully, by adding a  a grace period of 3x the reconnect timeout, to give it time to process a huge queues after connecting.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



