### PR TITLE
Fix uplink stall and off-heap memory growth after cloud disconnect

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/cloud/BaseCloudManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/cloud/BaseCloudManagerService.java
@@ -21,6 +21,8 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
+import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocatorMetric;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -28,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.thingsboard.common.util.ThingsBoardThreadFactory;
 import org.thingsboard.edge.rpc.EdgeRpcClient;
 import org.thingsboard.rule.engine.api.AttributesSaveRequest;
@@ -66,6 +69,7 @@ import org.thingsboard.server.service.executors.DbCallbackExecutorService;
 import org.thingsboard.server.service.state.DefaultDeviceStateService;
 import org.thingsboard.server.service.telemetry.TelemetrySubscriptionService;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -332,7 +336,7 @@ public abstract class BaseCloudManagerService extends TbApplicationEventListener
                 }
                 log.trace("processUplinkMessages state isInterrupted={},total={},hasNext={},isGeneralMsg={},isGeneralProcessInProgress={}",
                         isInterrupted, cloudEvents.getTotalElements(), cloudEvents.hasNext(), isGeneralMsg, isGeneralProcessInProgress);
-            } while (isInterrupted || cloudEvents.hasNext());
+            } while ((isInterrupted || cloudEvents.hasNext()) && edgeRpcClient.isConnected());
         } catch (Exception e) {
             log.error("Failed to process cloud event messages handling!", e);
         } finally {
@@ -881,8 +885,14 @@ public abstract class BaseCloudManagerService extends TbApplicationEventListener
 
                     if (!success) {
                         String batchPrefix = isGeneralMsg ? "General" : "Timeseries";
-                        log.warn("Failed to deliver {} batch (size: {}) on attempt {}", batchPrefix, pendingMsgMap.values().size(), attempt);
+                        log.info("Failed to deliver {} batch (size: {}) on attempt {}", batchPrefix, pendingMsgMap.values().size(), attempt);
                         log.trace("Entities in failed batch: {}", pendingMsgMap.values());
+                        if (!edgeRpcClient.isConnected()) {
+                            log.info("Cloud session is not established. {} uplink msg(s) are going to be retried after reconnect",
+                                    pendingMsgMap.size());
+                            sendUplinkFutureResult.set(true);
+                            return;
+                        }
                         try {
                             Thread.sleep(cloudEventStorageSettings.getSleepIntervalBetweenBatches());
 
@@ -916,6 +926,9 @@ public abstract class BaseCloudManagerService extends TbApplicationEventListener
     }
 
     private boolean sendUplinkMsgPack(LinkedBlockingQueue<UplinkMsg> orderedPendingMsgQueue) {
+        if (!edgeRpcClient.isConnected()) {
+            return false;
+        }
         sendingInProgress = true;
         try {
             latch = new CountDownLatch(pendingMsgMap.values().size());
@@ -949,6 +962,35 @@ public abstract class BaseCloudManagerService extends TbApplicationEventListener
 
     private boolean isSystemTenantPartitionMine() {
         return partitionService.resolve(ServiceType.TB_CORE, TenantId.SYS_TENANT_ID, TenantId.SYS_TENANT_ID).isMyPartition();
+    }
+
+    // TODO: temporary diagnostics for the gRPC direct-memory retention investigation, remove before merge.
+    // grpc-netty builds its own PooledByteBufAllocator instead of using PooledByteBufAllocator.DEFAULT,
+    // and the factory that owns it is package private - so the instance has to be pulled out reflectively.
+    @Scheduled(fixedRateString = "${cloud.direct_memory_log_interval_ms:10000}")
+    public void logDirectMemory() {
+        logGrpcAllocator("preferDirect", true);
+        logGrpcAllocator("preferHeap", false);
+    }
+
+    private void logGrpcAllocator(String name, boolean preferDirect) {
+        try {
+            Class<?> utils = Class.forName("io.grpc.netty.shaded.io.grpc.netty.Utils");
+            Method getByteBufAllocator = utils.getDeclaredMethod("getByteBufAllocator", boolean.class);
+            getByteBufAllocator.setAccessible(true);
+            Object allocator = getByteBufAllocator.invoke(null, preferDirect);
+            if (allocator instanceof PooledByteBufAllocator pooled) {
+                PooledByteBufAllocatorMetric metric = pooled.metric();
+                log.info("DIRECT MEMORY [{}] pinned={} used={} chunks={} arenas={} connected={}",
+                        name, pooled.pinnedDirectMemory(), metric.usedDirectMemory(),
+                        metric.usedDirectMemory() / metric.chunkSize(), metric.numDirectArenas(),
+                        edgeRpcClient.isConnected());
+            } else {
+                log.info("DIRECT MEMORY [{}] allocator is not pooled: {}", name, allocator);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to read the gRPC allocator metrics", e);
+        }
     }
 
     @FunctionalInterface

--- a/application/src/main/java/org/thingsboard/server/service/cloud/BaseCloudManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/cloud/BaseCloudManagerService.java
@@ -21,8 +21,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
-import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
-import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocatorMetric;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -30,7 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.thingsboard.common.util.ThingsBoardThreadFactory;
 import org.thingsboard.edge.rpc.EdgeRpcClient;
 import org.thingsboard.rule.engine.api.AttributesSaveRequest;
@@ -69,7 +66,6 @@ import org.thingsboard.server.service.executors.DbCallbackExecutorService;
 import org.thingsboard.server.service.state.DefaultDeviceStateService;
 import org.thingsboard.server.service.telemetry.TelemetrySubscriptionService;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -962,35 +958,6 @@ public abstract class BaseCloudManagerService extends TbApplicationEventListener
 
     private boolean isSystemTenantPartitionMine() {
         return partitionService.resolve(ServiceType.TB_CORE, TenantId.SYS_TENANT_ID, TenantId.SYS_TENANT_ID).isMyPartition();
-    }
-
-    // TODO: temporary diagnostics for the gRPC direct-memory retention investigation, remove before merge.
-    // grpc-netty builds its own PooledByteBufAllocator instead of using PooledByteBufAllocator.DEFAULT,
-    // and the factory that owns it is package private - so the instance has to be pulled out reflectively.
-    @Scheduled(fixedRateString = "${cloud.direct_memory_log_interval_ms:10000}")
-    public void logDirectMemory() {
-        logGrpcAllocator("preferDirect", true);
-        logGrpcAllocator("preferHeap", false);
-    }
-
-    private void logGrpcAllocator(String name, boolean preferDirect) {
-        try {
-            Class<?> utils = Class.forName("io.grpc.netty.shaded.io.grpc.netty.Utils");
-            Method getByteBufAllocator = utils.getDeclaredMethod("getByteBufAllocator", boolean.class);
-            getByteBufAllocator.setAccessible(true);
-            Object allocator = getByteBufAllocator.invoke(null, preferDirect);
-            if (allocator instanceof PooledByteBufAllocator pooled) {
-                PooledByteBufAllocatorMetric metric = pooled.metric();
-                log.info("DIRECT MEMORY [{}] pinned={} used={} chunks={} arenas={} connected={}",
-                        name, pooled.pinnedDirectMemory(), metric.usedDirectMemory(),
-                        metric.usedDirectMemory() / metric.chunkSize(), metric.numDirectArenas(),
-                        edgeRpcClient.isConnected());
-            } else {
-                log.info("DIRECT MEMORY [{}] allocator is not pooled: {}", name, allocator);
-            }
-        } catch (Exception e) {
-            log.warn("Failed to read the gRPC allocator metrics", e);
-        }
     }
 
     @FunctionalInterface

--- a/application/src/test/java/org/thingsboard/server/service/cloud/BaseCloudManagerServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/cloud/BaseCloudManagerServiceTest.java
@@ -369,6 +369,27 @@ public class BaseCloudManagerServiceTest {
     // already handle ExecutionException, whereas RejectedExecutionException crossing processCloudEvents
     // misses the Kafka catch and the batch is dropped without being committed. Completing as interrupted
     // would instead tell processUplinkMessages to re-query the same page forever.
+    @Test
+    void disconnectedTimeseriesPackStopsRetryingInsteadOfLoopingForever() throws Exception {
+        SettableFuture<Boolean> result = SettableFuture.create();
+        ReflectionTestUtils.setField(service, "sendUplinkFutureResult", result);
+        ScheduledExecutorService uplinkExecutor = Executors.newSingleThreadScheduledExecutor();
+        ReflectionTestUtils.setField(service, "uplinkExecutor", uplinkExecutor);
+        when(edgeRpcClient.isConnected()).thenReturn(false);
+
+        try {
+            ReflectionTestUtils.invokeMethod(service, "processMsgPack", List.of(uplinkMsg()), false);
+
+            // Timeseries packs have no attempt cap, so before the connectivity gate this loop retried a dead
+            // stream forever - parking the uplink thread and freezing the queue offset until a restart.
+            assertThat(result.get(TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                    .as("pack must complete as interrupted so the offset is not advanced").isTrue();
+            verify(edgeRpcClient, never()).sendUplinkMsg(any());
+        } finally {
+            uplinkExecutor.shutdownNow();
+        }
+    }
+
     private void assertPackRejected(ScheduledExecutorService executor) {
         SettableFuture<Boolean> result = SettableFuture.create();
         ReflectionTestUtils.setField(service, "sendUplinkFutureResult", result);

--- a/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
+++ b/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
@@ -19,8 +19,17 @@ import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.channel.Channel;
+import io.grpc.netty.shaded.io.netty.channel.EventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.epoll.Epoll;
+import io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.epoll.EpollSocketChannel;
+import io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
+import io.grpc.netty.shaded.io.netty.util.concurrent.DefaultThreadFactory;
 import io.grpc.stub.StreamObserver;
+import jakarta.annotation.PreDestroy;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -84,7 +93,11 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     private ManagedChannel channel;
 
+    private EventLoopGroup workerGroup;
+
     private StreamObserver<RequestMsg> inputStream;
+
+    private volatile boolean connected;
 
     private static final ReentrantLock uplinkMsgLock = new ReentrantLock();
 
@@ -95,7 +108,13 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                         Consumer<EdgeConfiguration> onEdgeUpdate,
                         Consumer<DownlinkMsg> onDownlink,
                         Consumer<Exception> onError) {
+        connected = false;
+        if (workerGroup == null) {
+            workerGroup = createWorkerGroup();
+        }
         NettyChannelBuilder builder = NettyChannelBuilder.forAddress(rpcHost, rpcPort)
+                .eventLoopGroup(workerGroup)
+                .channelType(channelType())
                 .maxInboundMessageSize(maxInboundMessageSize)
                 .keepAliveTime(keepAliveTimeSec, TimeUnit.SECONDS)
                 .keepAliveTimeout(keepAliveTimeoutSec, TimeUnit.SECONDS)
@@ -146,6 +165,22 @@ public class EdgeGrpcClient implements EdgeRpcClient {
         return EdgeVersionComparator.getNewestEdgeVersion();
     }
 
+    private static EventLoopGroup createWorkerGroup() {
+        DefaultThreadFactory threadFactory = new DefaultThreadFactory("edge-grpc-worker", true);
+        return Epoll.isAvailable() ? new EpollEventLoopGroup(1, threadFactory) : new NioEventLoopGroup(1, threadFactory);
+    }
+
+    private static Class<? extends Channel> channelType() {
+        return Epoll.isAvailable() ? EpollSocketChannel.class : NioSocketChannel.class;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (workerGroup != null) {
+            workerGroup.shutdownGracefully();
+        }
+    }
+
     private StreamObserver<ResponseMsg> initOutputStream(String edgeKey,
                                                          Consumer<UplinkResponseMsg> onUplinkResponse,
                                                          Consumer<EdgeConfiguration> onEdgeUpdate,
@@ -162,8 +197,10 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                             serverMaxInboundMessageSize = connectResponseMsg.getMaxInboundMessageSize();
                         }
                         log.info("[{}] Configuration received: {}", edgeKey, connectResponseMsg.getConfiguration());
+                        connected = true;
                         onEdgeUpdate.accept(connectResponseMsg.getConfiguration());
                     } else {
+                        connected = false;
                         log.error("[{}] Failed to establish the connection! Code: {}. Error message: {}.", edgeKey, connectResponseMsg.getResponseCode(), connectResponseMsg.getErrorMsg());
                         try {
                             EdgeGrpcClient.this.disconnect(true);
@@ -186,6 +223,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
             @Override
             public void onError(Throwable t) {
+                connected = false;
                 log.warn("[{}] Stream was terminated due to error:", edgeKey, t);
                 try {
                     EdgeGrpcClient.this.disconnect(true);
@@ -197,6 +235,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
             @Override
             public void onCompleted() {
+                connected = false;
                 log.info("[{}] Stream was closed and completed successfully!", edgeKey);
             }
         };
@@ -204,6 +243,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     @Override
     public void disconnect(boolean onError) throws InterruptedException {
+        connected = false;
         if (!onError) {
             try {
                 if (inputStream != null) {
@@ -237,9 +277,18 @@ public class EdgeGrpcClient implements EdgeRpcClient {
     }
 
     @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
     public void sendUplinkMsg(UplinkMsg msg) {
         uplinkMsgLock.lock();
         try {
+            if (!connected) {
+                log.debug("Uplink msg is skipped, the cloud session is not established: {}", msg);
+                return;
+            }
             this.inputStream.onNext(RequestMsg.newBuilder()
                     .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
                     .setUplinkMsg(msg)
@@ -253,6 +302,10 @@ public class EdgeGrpcClient implements EdgeRpcClient {
     public void sendSyncRequestMsg(boolean fullSyncRequired) {
         uplinkMsgLock.lock();
         try {
+            if (!connected) {
+                log.debug("Sync request msg is skipped, the cloud session is not established");
+                return;
+            }
             SyncRequestMsg syncRequestMsg = SyncRequestMsg.newBuilder()
                     .setFullSync(fullSyncRequired)
                     .build();
@@ -269,6 +322,10 @@ public class EdgeGrpcClient implements EdgeRpcClient {
     public void sendDownlinkResponseMsg(DownlinkResponseMsg downlinkResponseMsg) {
         uplinkMsgLock.lock();
         try {
+            if (!connected) {
+                log.debug("Downlink response msg is skipped, the cloud session is not established: {}", downlinkResponseMsg);
+                return;
+            }
             this.inputStream.onNext(RequestMsg.newBuilder()
                     .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
                     .setDownlinkResponseMsg(downlinkResponseMsg)

--- a/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
+++ b/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
@@ -93,7 +93,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     private ManagedChannel channel;
 
-    private EventLoopGroup workerGroup;
+    private final EventLoopGroup workerGroup = createWorkerGroup();
 
     private StreamObserver<RequestMsg> inputStream;
 
@@ -109,9 +109,6 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                         Consumer<DownlinkMsg> onDownlink,
                         Consumer<Exception> onError) {
         connected = false;
-        if (workerGroup == null) {
-            workerGroup = createWorkerGroup();
-        }
         NettyChannelBuilder builder = NettyChannelBuilder.forAddress(rpcHost, rpcPort)
                 .eventLoopGroup(workerGroup)
                 .channelType(channelType())
@@ -176,9 +173,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     @PreDestroy
     public void destroy() {
-        if (workerGroup != null) {
-            workerGroup.shutdownGracefully();
-        }
+        workerGroup.shutdownGracefully();
     }
 
     private StreamObserver<ResponseMsg> initOutputStream(String edgeKey,

--- a/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
+++ b/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
@@ -95,7 +95,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     private ManagedChannel channel;
 
-    private EventLoopGroup workerGroup;
+    private final EventLoopGroup workerGroup = createWorkerGroup();
 
     private StreamObserver<RequestMsg> inputStream;
 
@@ -111,9 +111,6 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                         Consumer<DownlinkMsg> onDownlink,
                         Consumer<Exception> onError) {
         connected = false;
-        if (workerGroup == null) {
-            workerGroup = createWorkerGroup();
-        }
         NettyChannelBuilder builder = NettyChannelBuilder.forAddress(rpcHost, rpcPort)
                 .eventLoopGroup(workerGroup)
                 .channelType(channelType())
@@ -178,9 +175,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     @PreDestroy
     public void destroy() {
-        if (workerGroup != null) {
-            workerGroup.shutdownGracefully();
-        }
+        workerGroup.shutdownGracefully();
     }
 
     private StreamObserver<ResponseMsg> initOutputStream(String edgeKey,

--- a/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
+++ b/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
@@ -19,8 +19,17 @@ import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.channel.Channel;
+import io.grpc.netty.shaded.io.netty.channel.EventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.epoll.Epoll;
+import io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.epoll.EpollSocketChannel;
+import io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
+import io.grpc.netty.shaded.io.netty.util.concurrent.DefaultThreadFactory;
 import io.grpc.stub.StreamObserver;
+import jakarta.annotation.PreDestroy;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -86,6 +95,8 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     private ManagedChannel channel;
 
+    private EventLoopGroup workerGroup;
+
     private StreamObserver<RequestMsg> inputStream;
 
     private volatile boolean connected;
@@ -100,7 +111,12 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                         Consumer<DownlinkMsg> onDownlink,
                         Consumer<Exception> onError) {
         connected = false;
+        if (workerGroup == null) {
+            workerGroup = createWorkerGroup();
+        }
         NettyChannelBuilder builder = NettyChannelBuilder.forAddress(rpcHost, rpcPort)
+                .eventLoopGroup(workerGroup)
+                .channelType(channelType())
                 .maxInboundMessageSize(maxInboundMessageSize)
                 .keepAliveTime(keepAliveTimeSec, TimeUnit.SECONDS)
                 .keepAliveTimeout(keepAliveTimeoutSec, TimeUnit.SECONDS)
@@ -149,6 +165,22 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     public static EdgeVersion getNewestEdgeVersion() {
         return EdgeVersionComparator.getNewestEdgeVersion();
+    }
+
+    private static EventLoopGroup createWorkerGroup() {
+        DefaultThreadFactory threadFactory = new DefaultThreadFactory("edge-grpc-worker", true);
+        return Epoll.isAvailable() ? new EpollEventLoopGroup(1, threadFactory) : new NioEventLoopGroup(1, threadFactory);
+    }
+
+    private static Class<? extends Channel> channelType() {
+        return Epoll.isAvailable() ? EpollSocketChannel.class : NioSocketChannel.class;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (workerGroup != null) {
+            workerGroup.shutdownGracefully();
+        }
     }
 
     private StreamObserver<ResponseMsg> initOutputStream(String edgeKey,

--- a/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
+++ b/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
@@ -88,6 +88,8 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     private StreamObserver<RequestMsg> inputStream;
 
+    private volatile boolean connected;
+
     private static final ReentrantLock uplinkMsgLock = new ReentrantLock();
 
     @Override
@@ -97,6 +99,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                         Consumer<EdgeConfiguration> onEdgeUpdate,
                         Consumer<DownlinkMsg> onDownlink,
                         Consumer<Exception> onError) {
+        connected = false;
         NettyChannelBuilder builder = NettyChannelBuilder.forAddress(rpcHost, rpcPort)
                 .maxInboundMessageSize(maxInboundMessageSize)
                 .keepAliveTime(keepAliveTimeSec, TimeUnit.SECONDS)
@@ -164,8 +167,10 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                             serverMaxInboundMessageSize = connectResponseMsg.getMaxInboundMessageSize();
                         }
                         log.info("[{}] Configuration received: {}", edgeKey, connectResponseMsg.getConfiguration());
+                        connected = true;
                         onEdgeUpdate.accept(connectResponseMsg.getConfiguration());
                     } else {
+                        connected = false;
                         log.error("[{}] Failed to establish the connection! Code: {}. Error message: {}.", edgeKey, connectResponseMsg.getResponseCode(), connectResponseMsg.getErrorMsg());
                         try {
                             EdgeGrpcClient.this.disconnect(true);
@@ -188,6 +193,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
             @Override
             public void onError(Throwable t) {
+                connected = false;
                 log.warn("[{}] Stream was terminated due to error:", edgeKey, t);
                 try {
                     EdgeGrpcClient.this.disconnect(true);
@@ -199,6 +205,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
             @Override
             public void onCompleted() {
+                connected = false;
                 log.info("[{}] Stream was closed and completed successfully!", edgeKey);
             }
         };
@@ -206,6 +213,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     @Override
     public void disconnect(boolean onError) throws InterruptedException {
+        connected = false;
         if (!onError) {
             try {
                 if (inputStream != null) {
@@ -239,9 +247,18 @@ public class EdgeGrpcClient implements EdgeRpcClient {
     }
 
     @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
     public void sendUplinkMsg(UplinkMsg msg) {
         uplinkMsgLock.lock();
         try {
+            if (!connected) {
+                log.debug("Uplink msg is skipped, the cloud session is not established: {}", msg);
+                return;
+            }
             this.inputStream.onNext(RequestMsg.newBuilder()
                     .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
                     .setUplinkMsg(msg)
@@ -255,6 +272,10 @@ public class EdgeGrpcClient implements EdgeRpcClient {
     public void sendSyncRequestMsg(boolean fullSyncRequired) {
         uplinkMsgLock.lock();
         try {
+            if (!connected) {
+                log.debug("Sync request msg is skipped, the cloud session is not established");
+                return;
+            }
             SyncRequestMsg syncRequestMsg = SyncRequestMsg.newBuilder()
                     .setFullSync(fullSyncRequired)
                     .build();
@@ -271,6 +292,10 @@ public class EdgeGrpcClient implements EdgeRpcClient {
     public void sendDownlinkResponseMsg(DownlinkResponseMsg downlinkResponseMsg) {
         uplinkMsgLock.lock();
         try {
+            if (!connected) {
+                log.debug("Downlink response msg is skipped, the cloud session is not established: {}", downlinkResponseMsg);
+                return;
+            }
             this.inputStream.onNext(RequestMsg.newBuilder()
                     .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
                     .setDownlinkResponseMsg(downlinkResponseMsg)

--- a/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeRpcClient.java
+++ b/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeRpcClient.java
@@ -34,6 +34,8 @@ public interface EdgeRpcClient {
 
     void disconnect(boolean onError) throws InterruptedException;
 
+    boolean isConnected();
+
     void sendSyncRequestMsg(boolean fullSyncRequired);
 
     void sendUplinkMsg(UplinkMsg uplinkMsg);

--- a/common/edge-api/src/test/java/org/thingsboard/edge/rpc/EdgeGrpcClientLeakTest.java
+++ b/common/edge-api/src/test/java/org/thingsboard/edge/rpc/EdgeGrpcClientLeakTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.edge.rpc;
+
+import io.grpc.Server;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.server.gen.edge.v1.ConnectResponseCode;
+import org.thingsboard.server.gen.edge.v1.ConnectResponseMsg;
+import org.thingsboard.server.gen.edge.v1.EdgeRpcServiceGrpc;
+import org.thingsboard.server.gen.edge.v1.RequestMsg;
+import org.thingsboard.server.gen.edge.v1.RequestMsgType;
+import org.thingsboard.server.gen.edge.v1.ResponseMsg;
+import org.thingsboard.server.gen.edge.v1.UplinkMsg;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class EdgeGrpcClientLeakTest {
+
+    // The window in which the default shared event loop group would be destroyed after the channel
+    // terminates (SharedResourceHolder delays destruction by 1 second). If EdgeGrpcClient ever goes
+    // back to the shared group, writes after this window hit a terminated executor and every buffer
+    // committed to grpc-netty's WriteQueue is pinned forever (4112 bytes per message, silent after
+    // the first RejectedExecutionException).
+    private static final long SHARED_GROUP_DEATH_WINDOW_MS = 3000;
+    private static final int MSG_COUNT = 50;
+    private static final long AWAIT_TIMEOUT_MS = 15_000;
+
+    private Server server;
+    private EdgeGrpcClient client;
+
+    @Test
+    void uplinksSentAfterTransportDeathDoNotPinPooledBuffers() throws Exception {
+        server = NettyServerBuilder.forPort(0)
+                .addService(new EdgeRpcServiceGrpc.EdgeRpcServiceImplBase() {
+                    @Override
+                    public StreamObserver<RequestMsg> handleMsgs(StreamObserver<ResponseMsg> outputStream) {
+                        return new StreamObserver<>() {
+                            @Override
+                            public void onNext(RequestMsg requestMsg) {
+                                if (requestMsg.hasConnectRequestMsg()) {
+                                    outputStream.onNext(ResponseMsg.newBuilder()
+                                            .setConnectResponseMsg(ConnectResponseMsg.newBuilder()
+                                                    .setResponseCode(ConnectResponseCode.ACCEPTED)
+                                                    .build())
+                                            .build());
+                                }
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                            }
+                        };
+                    }
+                })
+                .build()
+                .start();
+
+        client = new EdgeGrpcClient();
+        ReflectionTestUtils.setField(client, "rpcHost", "localhost");
+        ReflectionTestUtils.setField(client, "rpcPort", server.getPort());
+        ReflectionTestUtils.setField(client, "timeoutSecs", 1);
+        ReflectionTestUtils.setField(client, "keepAliveTimeSec", 10);
+        ReflectionTestUtils.setField(client, "keepAliveTimeoutSec", 5);
+        ReflectionTestUtils.setField(client, "maxInboundMessageSize", 4194304);
+
+        client.connect("leakTest", "leakTest", msg -> {}, cfg -> {}, msg -> {}, e -> {});
+        await("client to connect", () -> client.isConnected());
+
+        server.shutdownNow();
+        server.awaitTermination(10, TimeUnit.SECONDS);
+        await("client to observe the transport death", () -> !client.isConnected());
+        Thread.sleep(SHARED_GROUP_DEATH_WINDOW_MS);
+
+        long baseline = pinnedBytes();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RequestMsg> inputStream = (StreamObserver<RequestMsg>) ReflectionTestUtils.getField(client, "inputStream");
+        RequestMsg uplink = RequestMsg.newBuilder()
+                .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
+                .setUplinkMsg(UplinkMsg.newBuilder().setUplinkMsgId(1).build())
+                .build();
+        // Bypasses the connected gate on purpose: this models the check-then-act straggler (and the
+        // pre-gate retry loop) writing to a stream whose transport is already gone. Exceptions are
+        // swallowed the same way the production retry loop survives them.
+        for (int i = 0; i < MSG_COUNT; i++) {
+            try {
+                inputStream.onNext(uplink);
+            } catch (RuntimeException ignored) {
+            }
+        }
+
+        long deadline = System.currentTimeMillis() + AWAIT_TIMEOUT_MS;
+        while (pinnedBytes() > baseline) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("Pinned pooled memory did not return to baseline: " + (pinnedBytes() - baseline)
+                        + " bytes retained after " + MSG_COUNT + " uplinks to a dead stream");
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) {
+            client.disconnect(true);
+            client.destroy();
+        }
+        if (server != null) {
+            server.shutdownNow();
+        }
+    }
+
+    private void await(String what, BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + AWAIT_TIMEOUT_MS;
+        while (!condition.getAsBoolean()) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("Timed out waiting for " + what);
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    // grpc-netty builds its own PooledByteBufAllocator instances instead of using
+    // PooledByteBufAllocator.DEFAULT, and the factory that owns them is package private - so they
+    // have to be pulled out reflectively. Both variants are checked so the assertion holds no matter
+    // which one the transport picks on this platform/version.
+    private static long pinnedBytes() {
+        try {
+            Class<?> utils = Class.forName("io.grpc.netty.shaded.io.grpc.netty.Utils");
+            Method getByteBufAllocator = utils.getDeclaredMethod("getByteBufAllocator", boolean.class);
+            getByteBufAllocator.setAccessible(true);
+            long total = 0;
+            for (boolean forceHeapBuffer : new boolean[]{false, true}) {
+                PooledByteBufAllocator pooled = (PooledByteBufAllocator) getByteBufAllocator.invoke(null, forceHeapBuffer);
+                total += pooled.pinnedDirectMemory() + pooled.pinnedHeapMemory();
+            }
+            return total;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to read the gRPC allocator metrics", e);
+        }
+    }
+
+}


### PR DESCRIPTION
## Pull Request description

This PR resolves the issue mentioned in: https://github.com/thingsboard/thingsboard-edge/issues/229#issuecomment-5192355521

There's a case when the message gets send via `inputStream.onNext`, and the underlying Netty's `eventLoopGroup` used by GRPC gets closed / shut-down (in edge's case - disconnect-reconnect cycles): 
- On outbound message write, Java GRPC allocates the Netty's `ByteBuf` (direct, meaning - stored off-heap, inside native memory) per message. 
It's never released unless the application dies because the `eventLoopGroup` is shutdown -  `RejectedExecutionException("event executor terminated")` is thrown on `inputStream.onNext`.
Consequence: the native memory grows indefinitely on each disconnect-reconnect cycle, if the message happens to be in mid-processing state, when **default (configured by GRPC)** `eventLoopGroup` is being shutdown

The path above is reproduced via `BaseCloudManagerService#scheduleMsgPack`.
### Fix
- **Own the gRPC worker event loop group** (`EdgeGrpcClient`) instead of using gRPC's shared one, so
  it survives disconnect/reconnect cycles. The executor is never terminated, so the leak cannot
  occur. Sized at one I/O thread - the edge maintains a single channel with one bidi stream.
- **Gate uplink sends on an established session** (`EdgeRpcClient#isConnected`). `sendUplinkMsg`,
  `sendSyncRequestMsg` and `sendDownlinkResponseMsg` no longer call `onNext` after the session is
  gone, which is also what the gRPC `StreamObserver` contract requires.
- **Exit the retry loop while disconnected.** The batch completes as *interrupted*, so the queue
  offset is not advanced and no messages are discarded — the batch replays after reconnect.


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



